### PR TITLE
이미지 확장자 대소문자 구분 이슈 조치

### DIFF
--- a/src/main/java/site/packit/packit/domain/image/service/AmazonS3ImageService.java
+++ b/src/main/java/site/packit/packit/domain/image/service/AmazonS3ImageService.java
@@ -56,7 +56,7 @@ public class AmazonS3ImageService implements ImageService {
     }
 
     private String parseImageExtension(String originalImageName) {
-        return originalImageName.substring(originalImageName.lastIndexOf(".") + 1);
+        return originalImageName.substring(originalImageName.lastIndexOf(".") + 1).toLowerCase();
     }
 
     private String generateStoredImageNameFromOriginalImageName(String originalImageName) {


### PR DESCRIPTION
유효한 확장자를 가진 이미지를 업로드 시 이미지의 확장자가 대문자면 유효성 검증을 통과하지 못하는 문제가 발생하였다.
따라서 업로드 된 이미지의 확장자를 추출 후 소문자로 치환하여 검증하도록 로직을 수정하였다.

This closes #12 