### PR TITLE
[Backend] 인증 전략 수정 및 프론트 요구사항 적용

### DIFF
--- a/src/main/java/site/packit/packit/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/packit/packit/domain/auth/controller/AuthController.java
@@ -16,10 +16,10 @@ import site.packit.packit.domain.auth.service.MobileAuthService;
 import site.packit.packit.domain.auth.service.WebAuthService;
 import site.packit.packit.global.response.success.SingleSuccessApiResponse;
 import site.packit.packit.global.response.success.SuccessApiResponse;
-import site.packit.packit.global.response.util.ResponseUtil;
 
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
+import static site.packit.packit.global.response.util.ResponseUtil.successApiResponse;
 
 @RequestMapping("/api/auth")
 @RestController
@@ -37,14 +37,14 @@ public class AuthController {
     public ResponseEntity<SingleSuccessApiResponse<MobileLoginResponse>> login(@RequestBody MobileLoginRequest request) {
         MobileLoginResponse loginResult = mobileAuthService.login(request);
 
-        return ResponseUtil.successApiResponse(OK, "성공적으로 로그인 되었습니다.", loginResult);
+        return successApiResponse(OK, "성공적으로 로그인 되었습니다.", loginResult);
     }
 
     @DeleteMapping("/mobile/logout")
     public ResponseEntity<SuccessApiResponse> logout(@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
         mobileAuthService.logout(userPrincipal.getUsername());
 
-        return ResponseUtil.successApiResponse(OK, "성공적으로 로그아웃 되었습니다.");
+        return successApiResponse(OK, "성공적으로 로그아웃 되었습니다.");
     }
 
     @PostMapping("/mobile/refresh")
@@ -52,14 +52,14 @@ public class AuthController {
         AuthenticationTokens authenticationTokens = mobileAuthService.reissueToken(request);
         MobileTokenReissueResponse mobileTokenReissueResponse = MobileTokenReissueResponse.of(authenticationTokens);
 
-        return ResponseUtil.successApiResponse(CREATED, "성공적으로 토큰이 재발급 되었습니다.", mobileTokenReissueResponse);
+        return successApiResponse(CREATED, "성공적으로 토큰이 재발급 되었습니다.", mobileTokenReissueResponse);
     }
 
     @DeleteMapping("/web/logout")
     public ResponseEntity<SuccessApiResponse> logout(@AuthenticationPrincipal CustomUserPrincipal userPrincipal, HttpServletRequest request, HttpServletResponse response) {
         webAuthService.logout(request, response, userPrincipal.getUsername());
 
-        return ResponseUtil.successApiResponse(OK, "성공적으로 로그아웃 되었습니다.");
+        return successApiResponse(OK, "성공적으로 로그아웃 되었습니다.");
     }
 
     @PostMapping("/web/refresh")
@@ -67,6 +67,6 @@ public class AuthController {
         String newAccessToken = webAuthService.reissueToken(request, response);
         WebTokenReissueResponse webTokenReissueResponse = WebTokenReissueResponse.of(newAccessToken);
 
-        return ResponseUtil.successApiResponse(CREATED, "성공적으로 토큰이 재발급 되었습니다.", webTokenReissueResponse);
+        return successApiResponse(CREATED, "성공적으로 토큰이 재발급 되었습니다.", webTokenReissueResponse);
     }
 }

--- a/src/main/java/site/packit/packit/domain/auth/dto/mobile/response/MobileLoginResponse.java
+++ b/src/main/java/site/packit/packit/domain/auth/dto/mobile/response/MobileLoginResponse.java
@@ -1,6 +1,5 @@
 package site.packit.packit.domain.auth.dto.mobile.response;
 
-public record MobileLoginResponse(String memberStatus, String accessToken, String refreshToken,
-                                  String memberPersonalId) {
+public record MobileLoginResponse(String memberStatus, String accessToken, String refreshToken) {
 
 }

--- a/src/main/java/site/packit/packit/domain/auth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/site/packit/packit/domain/auth/filter/TokenAuthenticationFilter.java
@@ -23,8 +23,8 @@ import static site.packit.packit.domain.member.constant.AccountStatus.WAITING_TO
 
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final List<String> REGISTER_REQUEST_URI = List.of("/api/members", "/api/members/nicknames/is-duplicate", "/api/images");
     private static final List<String> TOKEN_REISSUE_REQUEST_URI = List.of("/api/auth/web/refresh", "/api/auth/mobile/refresh");
-    private static final List<String> REGISTER_REQUEST_URI = List.of("/api/members", "/api/images");
 
     private final GlobalAuthService globalAuthService;
 

--- a/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
+++ b/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import site.packit.packit.domain.auth.principal.CustomUserPrincipal;
-import site.packit.packit.domain.member.dto.business.MemberDto;
+import site.packit.packit.domain.member.dto.MemberDto;
 import site.packit.packit.domain.member.dto.request.UpdateMemberProfileRequest;
 import site.packit.packit.domain.member.dto.response.GetMemberProfileResponse;
 import site.packit.packit.domain.member.dto.response.RegisterResponse;
@@ -26,11 +26,15 @@ public class MemberController {
         this.memberService = memberService;
     }
 
-    @PostMapping
-    public ResponseEntity<SingleSuccessApiResponse<RegisterResponse>> register(@RequestParam("member-personal-id") String memberPersonalId, @RequestBody UpdateMemberProfileRequest request) {
-        Long registerMemberId = memberService.register(memberPersonalId, request);
+    @PostMapping()
+    public ResponseEntity<SingleSuccessApiResponse<RegisterResponse>> register(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            @RequestBody UpdateMemberProfileRequest updateMemberProfileRequest
+    ) {
+        Long registerMemberId = memberService.register(userPrincipal.getMemberId(), updateMemberProfileRequest);
+        RegisterResponse response = RegisterResponse.of(registerMemberId);
 
-        return successApiResponse(OK, "성공적으로 회원가입되었습니다.", RegisterResponse.of(registerMemberId));
+        return successApiResponse(OK, "성공적으로 회원가입되었습니다.", response);
     }
 
     @GetMapping("/profiles")

--- a/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
+++ b/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
@@ -5,7 +5,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import site.packit.packit.domain.auth.principal.CustomUserPrincipal;
 import site.packit.packit.domain.member.dto.MemberDto;
+import site.packit.packit.domain.member.dto.request.CheckMemberNicknameDuplicatedRequest;
 import site.packit.packit.domain.member.dto.request.UpdateMemberProfileRequest;
+import site.packit.packit.domain.member.dto.response.CheckMemberNicknameDuplicatedResponse;
 import site.packit.packit.domain.member.dto.response.GetMemberProfileResponse;
 import site.packit.packit.domain.member.dto.response.RegisterResponse;
 import site.packit.packit.domain.member.service.MemberService;
@@ -60,5 +62,13 @@ public class MemberController {
         memberService.deleteMember(principal.getMemberId());
 
         return ResponseUtil.successApiResponse(OK, "성공적으로 사용자 정보가 삭제되었습니다.");
+    }
+
+    @GetMapping("/nicknames/is-duplicate")
+    public ResponseEntity<SingleSuccessApiResponse<CheckMemberNicknameDuplicatedResponse>> checkMemberNicknameDuplicated(@RequestBody CheckMemberNicknameDuplicatedRequest request) {
+        boolean isDuplicated = memberService.checkMemberNicknameDuplicated(request.nickname());
+        CheckMemberNicknameDuplicatedResponse response = new CheckMemberNicknameDuplicatedResponse(isDuplicated);
+
+        return ResponseUtil.successApiResponse(OK, "사용자 닉네임 중복 검증 결과 입니다.", response);
     }
 }

--- a/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
+++ b/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
@@ -71,4 +71,18 @@ public class MemberController {
 
         return ResponseUtil.successApiResponse(OK, "사용자 닉네임 중복 검증 결과 입니다.", response);
     }
+
+    @PutMapping("/enable-notification")
+    public ResponseEntity<SuccessApiResponse> enableNotification(@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        memberService.enableNotification(userPrincipal.getMemberId());
+
+        return ResponseUtil.successApiResponse(OK, "푸시 알림이 활성화 되었습니다.");
+    }
+
+    @PutMapping("/disable-notification")
+    public ResponseEntity<SuccessApiResponse> disableNotification(@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        memberService.disableNotification(userPrincipal.getMemberId());
+
+        return ResponseUtil.successApiResponse(OK, "푸시 알림이 비 활성화 되었습니다.");
+    }
 }

--- a/src/main/java/site/packit/packit/domain/member/dto/MemberDto.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/MemberDto.java
@@ -12,7 +12,8 @@ public record MemberDto(
         String profileImageUrl,
         AccountStatus accountStatus,
         AccountRole accountRole,
-        LoginProvider loginProvider
+        LoginProvider loginProvider,
+        boolean enableNotification
 ) {
     public static MemberDto of(Member member) {
         return new MemberDto(
@@ -22,7 +23,8 @@ public record MemberDto(
                 member.getProfileImageUrl(),
                 member.getAccountStatus(),
                 member.getAccountRole(),
-                member.getLoginProvider()
+                member.getLoginProvider(),
+                member.isEnableNotification()
         );
     }
 }

--- a/src/main/java/site/packit/packit/domain/member/dto/MemberDto.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/MemberDto.java
@@ -1,4 +1,4 @@
-package site.packit.packit.domain.member.dto.business;
+package site.packit.packit.domain.member.dto;
 
 import site.packit.packit.domain.member.constant.AccountRole;
 import site.packit.packit.domain.member.constant.AccountStatus;

--- a/src/main/java/site/packit/packit/domain/member/dto/request/CheckMemberNicknameDuplicatedRequest.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/request/CheckMemberNicknameDuplicatedRequest.java
@@ -1,0 +1,4 @@
+package site.packit.packit.domain.member.dto.request;
+
+public record CheckMemberNicknameDuplicatedRequest(String nickname) {
+}

--- a/src/main/java/site/packit/packit/domain/member/dto/request/UpdateMemberProfileRequest.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/request/UpdateMemberProfileRequest.java
@@ -1,7 +1,4 @@
 package site.packit.packit.domain.member.dto.request;
 
-public record UpdateMemberProfileRequest(
-        String nickname,
-        String profileImageUrl
-) {
+public record UpdateMemberProfileRequest(String nickname, String profileImageUrl) {
 }

--- a/src/main/java/site/packit/packit/domain/member/dto/request/UpdateMemberProfileRequest.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/request/UpdateMemberProfileRequest.java
@@ -1,4 +1,9 @@
 package site.packit.packit.domain.member.dto.request;
 
-public record UpdateMemberProfileRequest(String nickname, String profileImageUrl) {
+public record UpdateMemberProfileRequest(
+        String nickname,
+        String profileImageUrl,
+        boolean enableNotification,
+        boolean checkTerms
+) {
 }

--- a/src/main/java/site/packit/packit/domain/member/dto/response/CheckMemberNicknameDuplicatedResponse.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/response/CheckMemberNicknameDuplicatedResponse.java
@@ -1,0 +1,4 @@
+package site.packit.packit.domain.member.dto.response;
+
+public record CheckMemberNicknameDuplicatedResponse(boolean isDuplicated) {
+}

--- a/src/main/java/site/packit/packit/domain/member/dto/response/GetMemberProfileResponse.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/response/GetMemberProfileResponse.java
@@ -1,6 +1,6 @@
 package site.packit.packit.domain.member.dto.response;
 
-import site.packit.packit.domain.member.dto.business.MemberDto;
+import site.packit.packit.domain.member.dto.MemberDto;
 
 public record GetMemberProfileResponse(
         Long id,

--- a/src/main/java/site/packit/packit/domain/member/dto/response/GetMemberProfileResponse.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/response/GetMemberProfileResponse.java
@@ -5,9 +5,10 @@ import site.packit.packit.domain.member.dto.MemberDto;
 public record GetMemberProfileResponse(
         Long id,
         String nickname,
-        String profileImageUrl
+        String profileImageUrl,
+        boolean enableNotification
 ) {
     public static GetMemberProfileResponse of(MemberDto memberDto) {
-        return new GetMemberProfileResponse(memberDto.id(), memberDto.nickName(), memberDto.profileImageUrl());
+        return new GetMemberProfileResponse(memberDto.id(), memberDto.nickName(), memberDto.profileImageUrl(), memberDto.enableNotification());
     }
 }

--- a/src/main/java/site/packit/packit/domain/member/dto/response/RegisterResponse.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/response/RegisterResponse.java
@@ -1,8 +1,6 @@
 package site.packit.packit.domain.member.dto.response;
 
-public record RegisterResponse(
-        Long memberId
-) {
+public record RegisterResponse(Long memberId) {
 
     public static RegisterResponse of(Long memberId) {
         return new RegisterResponse(memberId);

--- a/src/main/java/site/packit/packit/domain/member/entity/Member.java
+++ b/src/main/java/site/packit/packit/domain/member/entity/Member.java
@@ -50,6 +50,12 @@ public class Member extends BaseTimeEntity {
     @Column(length = 50, nullable = false, updatable = false)
     private LoginProvider loginProvider;
 
+    @Column(nullable = false)
+    private boolean enableNotification;
+
+    @Column(nullable = false)
+    private boolean checkTerms;
+
     private Member(
             String personalId,
             String nickname,
@@ -64,6 +70,8 @@ public class Member extends BaseTimeEntity {
         this.accountStatus = accountStatus;
         this.accountRole = accountRole;
         this.loginProvider = loginProvider;
+        this.checkTerms = false;
+        this.enableNotification = false;
     }
 
     public static Member createTempUser(String personalId, LoginProvider loginProvider) {
@@ -77,18 +85,39 @@ public class Member extends BaseTimeEntity {
         );
     }
 
-    public void register(String nickname, String profileImageUrl) {
+    public void register(
+            String nickname,
+            String profileImageUrl,
+            boolean enableNotification,
+            boolean checkTerms
+    ) {
         updateMemberProfile(nickname, profileImageUrl);
-        this.accountStatus = ACTIVE;
-    }
 
-    public Collection<GrantedAuthority> getGrantedAuthorities() {
-        return List.of(new SimpleGrantedAuthority(accountRole.toString()));
+        if ((enableNotification)) {
+            enableNotification();
+        } else {
+            disableNotification();
+        }
+
+        this.checkTerms = checkTerms;
+        this.accountStatus = ACTIVE;
     }
 
     public void updateMemberProfile(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void enableNotification() {
+        this.enableNotification = true;
+    }
+
+    public void disableNotification() {
+        this.enableNotification = false;
+    }
+
+    public Collection<GrantedAuthority> getGrantedAuthorities() {
+        return List.of(new SimpleGrantedAuthority(accountRole.toString()));
     }
 
     public void remove() {

--- a/src/main/java/site/packit/packit/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/packit/packit/domain/member/repository/MemberRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByPersonalId(String personalId);
+    Optional<Member> findByIdAndAccountStatus(Long memberId, AccountStatus accountStatus);
 
-    Optional<Member> findByPersonalIdAndAccountStatus(String personalId, AccountStatus accountStatus);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/site/packit/packit/domain/member/service/MemberService.java
+++ b/src/main/java/site/packit/packit/domain/member/service/MemberService.java
@@ -3,7 +3,7 @@ package site.packit.packit.domain.member.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.packit.packit.domain.member.constant.LoginProvider;
-import site.packit.packit.domain.member.dto.business.MemberDto;
+import site.packit.packit.domain.member.dto.MemberDto;
 import site.packit.packit.domain.member.dto.request.UpdateMemberProfileRequest;
 import site.packit.packit.domain.member.entity.Member;
 import site.packit.packit.domain.member.exception.MemberException;
@@ -33,12 +33,16 @@ public class MemberService {
         return memberRepository.save(Member.createTempUser(personalId, loginProvider));
     }
 
-    public Long register(String personalId, UpdateMemberProfileRequest request) {
-        Member tempMember = memberRepository.findByPersonalIdAndAccountStatus(personalId, WAITING_TO_JOIN)
-                .orElseThrow(() -> new MemberException(TEMP_MEMBER_NOT_FOUND));
+    public Long register(Long memberId, UpdateMemberProfileRequest request) {
+        Member tempMember = getTempMember(memberId);
         tempMember.register(request.nickname(), request.profileImageUrl());
 
         return tempMember.getId();
+    }
+
+    private Member getTempMember(Long memberId) {
+        return memberRepository.findByIdAndAccountStatus(memberId, WAITING_TO_JOIN)
+                .orElseThrow(() -> new MemberException(TEMP_MEMBER_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/site/packit/packit/domain/member/service/MemberService.java
+++ b/src/main/java/site/packit/packit/domain/member/service/MemberService.java
@@ -6,6 +6,7 @@ import site.packit.packit.domain.member.constant.LoginProvider;
 import site.packit.packit.domain.member.dto.MemberDto;
 import site.packit.packit.domain.member.dto.request.UpdateMemberProfileRequest;
 import site.packit.packit.domain.member.entity.Member;
+import site.packit.packit.domain.member.exception.MemberErrorCode;
 import site.packit.packit.domain.member.exception.MemberException;
 import site.packit.packit.domain.member.repository.MemberRepository;
 
@@ -74,5 +75,17 @@ public class MemberService {
     @Transactional(readOnly = true)
     public boolean checkMemberNicknameDuplicated(String memberNickname) {
         return memberRepository.existsByNickname(memberNickname);
+    }
+
+    public void enableNotification(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+        member.enableNotification();
+    }
+
+    public void disableNotification(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+        member.disableNotification();
     }
 }

--- a/src/main/java/site/packit/packit/domain/member/service/MemberService.java
+++ b/src/main/java/site/packit/packit/domain/member/service/MemberService.java
@@ -70,4 +70,9 @@ public class MemberService {
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
         member.remove();
     }
+
+    @Transactional(readOnly = true)
+    public boolean checkMemberNicknameDuplicated(String memberNickname) {
+        return memberRepository.existsByNickname(memberNickname);
+    }
 }

--- a/src/main/java/site/packit/packit/domain/member/service/MemberService.java
+++ b/src/main/java/site/packit/packit/domain/member/service/MemberService.java
@@ -35,7 +35,7 @@ public class MemberService {
 
     public Long register(Long memberId, UpdateMemberProfileRequest request) {
         Member tempMember = getTempMember(memberId);
-        tempMember.register(request.nickname(), request.profileImageUrl());
+        tempMember.register(request.nickname(), request.profileImageUrl(), request.enableNotification(), request.checkTerms());
 
         return tempMember.getId();
     }

--- a/src/main/java/site/packit/packit/global/security/SecurityConfig.java
+++ b/src/main/java/site/packit/packit/global/security/SecurityConfig.java
@@ -31,8 +31,7 @@ public class SecurityConfig {
             PermitAllPattern.of("/api/auth/mobile/login", POST),
             PermitAllPattern.of("/api/auth/web/refresh", POST),
             PermitAllPattern.of("/api/auth/mobile/refresh", POST),
-            PermitAllPattern.of("/api/check", GET),
-            PermitAllPattern.of("/api/members", POST)
+            PermitAllPattern.of("/api/check", GET)
     );
 
     private final TokenService tokenService;

--- a/src/main/java/site/packit/packit/global/util/LoginResponseUtil.java
+++ b/src/main/java/site/packit/packit/global/util/LoginResponseUtil.java
@@ -6,30 +6,17 @@ import site.packit.packit.domain.member.constant.AccountStatus;
 
 public class LoginResponseUtil {
 
-    public static String createRedirectUriForActiveMember(
+    public static String createRedirectUriForActiveOrWaitingToJoinMember(
             String redirectUrl,
             AccountStatus accountStatus,
             String accessToken
-    ) {
+            ) {
         return UriComponentsBuilder.fromUriString(redirectUrl)
                 .queryParam("member-status", accountStatus.name())
                 .queryParam("access-token", accessToken)
                 .build()
                 .toUriString();
     }
-
-    public static String createRedirectUriForWaitingToJoinMember(
-            String redirectUrl,
-            AccountStatus accountStatus,
-            String memberPersonalId
-    ) {
-        return UriComponentsBuilder.fromUriString(redirectUrl)
-                .queryParam("member-status", accountStatus.name())
-                .queryParam("member-personal-id", memberPersonalId)
-                .build()
-                .toUriString();
-    }
-
     public static String createRedirectUriForDeleteMember(String redirectUrl, AccountStatus accountStatus) {
         return UriComponentsBuilder.fromUriString(redirectUrl)
                 .queryParam("member-status", accountStatus.name())
@@ -37,15 +24,11 @@ public class LoginResponseUtil {
                 .toUriString();
     }
 
-    public static MobileLoginResponse createActiveMemberLoginResponse(AccountStatus accountStatus, String accessToken, String refreshToken) {
-        return new MobileLoginResponse(accountStatus.name(), accessToken, refreshToken, "");
-    }
-
-    public static MobileLoginResponse createWaitingToJoinMemberLoginResponse(AccountStatus accountStatus, String memberPersonalId) {
-        return new MobileLoginResponse(accountStatus.name(), "", "", memberPersonalId);
+    public static MobileLoginResponse createActiveMemberOrWaitingToJoinLoginResponse(AccountStatus accountStatus, String accessToken, String refreshToken) {
+        return new MobileLoginResponse(accountStatus.name(), accessToken, refreshToken);
     }
 
     public static MobileLoginResponse createDeleteMemberLoginResponse(AccountStatus accountStatus) {
-        return new MobileLoginResponse(accountStatus.name(), "", "", "");
+        return new MobileLoginResponse(accountStatus.name(), "", "");
     }
 }


### PR DESCRIPTION
최초 로그인 회원에 대한 인증 전략을 수정하고 프론트 요구사항을 반영하였다.
- 최초 로그인 회원에 제한적인 권한의 토큰을 발급하는 전략으로 수정
- 프론트 요구사항 반영
  - 회원가입 시 푸시 알림 수신 여부와 약관 동의 여부를 받도록 API 수정
  - 프로필 조회시 푸시 알림 수신 여부가 함께 넘어오도록 수정
  - 푸시 알림 활성화 & 비 활성화 API 개발
  - 닉네임 중복 검증 API 개발

This closes #15 