### PR TITLE
[Backend] 닉네임 중복 검증 API 수정

### DIFF
--- a/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
+++ b/src/main/java/site/packit/packit/domain/member/controller/MemberController.java
@@ -5,7 +5,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import site.packit.packit.domain.auth.principal.CustomUserPrincipal;
 import site.packit.packit.domain.member.dto.MemberDto;
-import site.packit.packit.domain.member.dto.request.CheckMemberNicknameDuplicatedRequest;
 import site.packit.packit.domain.member.dto.request.UpdateMemberProfileRequest;
 import site.packit.packit.domain.member.dto.response.CheckMemberNicknameDuplicatedResponse;
 import site.packit.packit.domain.member.dto.response.GetMemberProfileResponse;
@@ -65,8 +64,8 @@ public class MemberController {
     }
 
     @GetMapping("/nicknames/is-duplicate")
-    public ResponseEntity<SingleSuccessApiResponse<CheckMemberNicknameDuplicatedResponse>> checkMemberNicknameDuplicated(@RequestBody CheckMemberNicknameDuplicatedRequest request) {
-        boolean isDuplicated = memberService.checkMemberNicknameDuplicated(request.nickname());
+    public ResponseEntity<SingleSuccessApiResponse<CheckMemberNicknameDuplicatedResponse>> checkMemberNicknameDuplicated(@RequestParam String nickname) {
+        boolean isDuplicated = memberService.checkMemberNicknameDuplicated(nickname);
         CheckMemberNicknameDuplicatedResponse response = new CheckMemberNicknameDuplicatedResponse(isDuplicated);
 
         return ResponseUtil.successApiResponse(OK, "사용자 닉네임 중복 검증 결과 입니다.", response);

--- a/src/main/java/site/packit/packit/domain/member/dto/request/CheckMemberNicknameDuplicatedRequest.java
+++ b/src/main/java/site/packit/packit/domain/member/dto/request/CheckMemberNicknameDuplicatedRequest.java
@@ -1,4 +1,0 @@
-package site.packit.packit.domain.member.dto.request;
-
-public record CheckMemberNicknameDuplicatedRequest(String nickname) {
-}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    default: dev
+    default: prod


### PR DESCRIPTION
GET 메서드를 사용하는 API이므로 바디가 아닌 쿼리 파라미터에 요청 데이터를 넣도록 로직을 수정하였다.

This closes #19 